### PR TITLE
Add feature flag for both platform and sites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,8 @@ feature. But mostly it's a configuration model in the admin panel available unde
 Next, install LingoX and configure it:
 
 - ``$ pip install -e git+https://github.com/appsembler/LingoX.git#egg=lingox``
-- Add ``lingox`` to the ``ADDL_INSTALLED_APPS`` in the ``lms.env.json`` (or your ``server-vars.yml``)
+- Add ``lingox`` to ``ADDL_INSTALLED_APPS`` in the ``lms.env.json`` (or your ``server-vars.yml``)
+- Set ``FEATURES['ENABLE_LINGOX']`` to ``true`` in the ``lms.env.json`` (or your ``server-vars.yml``)
 - Set ``LANGUAGE_CODE`` to ``ar``
 - Reload the server
 - Open a new incognito window on ``http://localhost:8000/``, you should see an Arabic interface
@@ -58,6 +59,8 @@ Next, install LingoX and configure it:
   language for a specific site: go to Sites
   Configuration ``/admin/site_configuration/siteconfiguration/``, add a ``LANGUAGE_CODE`` key with the desired
   site-specific value to the site's configuration JSON.
+  To enable or disable the feature on a specific site, define the variable ``ENABLE_LINGOX`` in the site's
+  configuration JSON.
 
 Support Custom API Endpoints
   To retain compatibility with the mobile applications, LingoX will avoid tampering the

--- a/lingox/helpers.py
+++ b/lingox/helpers.py
@@ -8,6 +8,8 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -86,3 +88,11 @@ def is_api_request(request):
             return True
 
     return False
+
+
+def is_feature_enabled():
+    """
+    Check if the feature is enabled for the Site or for the platform as a whole.
+    """
+    is_enabled_in_platform = settings.FEATURES.get('ENABLE_LINGOX', False)
+    return configuration_helpers.get_value('ENABLE_LINGOX', is_enabled_in_platform)

--- a/lingox/middleware.py
+++ b/lingox/middleware.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 
-from lingox.helpers import is_api_request
+from lingox.helpers import is_api_request, is_feature_enabled
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
@@ -21,18 +21,25 @@ class DefaultLocaleMiddleware(object):
     specifically django.middleware.locale.LocaleMiddleware
     """
 
+    def patch_request(self, request):
+        """
+        Enforce LANGUAGE_CODE regardless of the browser provided language.
+
+        Django will use this value in the LocaleMiddleware to display the desired language.
+        """
+        if 'HTTP_ACCEPT_LANGUAGE' in request.META:
+            # Preserve the browser provided language just in case,
+            # the underscore prefix means that you probably shouldn't be using it anyway
+            request.META['_HTTP_ACCEPT_LANGUAGE'] = request.META['HTTP_ACCEPT_LANGUAGE']
+
+        language_code = configuration_helpers.get_value('LANGUAGE_CODE', settings.LANGUAGE_CODE)
+        request.META['HTTP_ACCEPT_LANGUAGE'] = language_code
+
     def process_request(self, request):
         """
         Change the request's `HTTP_ACCEPT_LANGUAGE` to `settings.LANGUAGE_CODE`.
         """
-        # This middleware is only needed for regular browser pages. It is incompatible with the mobile apps.
-        if not is_api_request(request):
-            if 'HTTP_ACCEPT_LANGUAGE' in request.META:
-                # Preserve the browser provided language just in case,
-                # the underscore prefix means that you probably shouldn't be using it anyway
-                request.META['_HTTP_ACCEPT_LANGUAGE'] = request.META['HTTP_ACCEPT_LANGUAGE']
-
-            # Enforce LANGUAGE_CODE regardless of the browser provided language
-            # Django will use this value in the LocaleMiddleware to display the desired language
-            language_code = configuration_helpers.get_value('LANGUAGE_CODE', settings.LANGUAGE_CODE)
-            request.META['HTTP_ACCEPT_LANGUAGE'] = language_code
+        # This middleware is only needed for regular browser pages.
+        # It is incompatible with the mobile apps and APIs in general.
+        if is_feature_enabled() and not is_api_request(request):
+            self.patch_request(request)

--- a/test_settings.py
+++ b/test_settings.py
@@ -27,6 +27,11 @@ MOCK_SITE_CONFIGS = {}
 # Dummy value to emulate the Open edX `ENV_TOKENS` in `aws.py`.
 ENV_TOKENS = {}
 
+# Dummy feature flags dictionary.
+FEATURES = {
+    'ENABLE_LINGOX': False,  # The feature is disabled by default.
+}
+
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Allow the plugin to be used by Tahoe, by letting individual sites disabling the feature.